### PR TITLE
Graceful exit

### DIFF
--- a/MainServer.hpp
+++ b/MainServer.hpp
@@ -12,6 +12,7 @@
 #include <thread>
 #include <mutex>
 #include "loguru.hpp"
+#include "common.hpp"
 #include "packets.hpp"
 #include "Tracker.hpp"
 

--- a/ReliableMainServer.cpp
+++ b/ReliableMainServer.cpp
@@ -58,7 +58,8 @@ void ReliableMainServer::_process_packet(const Packet& packet)  {
 
 
 void ReliableMainServer::_tr_update_last_seq_map() {
-    while (true) {
+    loguru::set_thread_name("RelMainServer:PacketLastSeq");
+    while (! process_stop) {
         {
             std::lock_guard<std::mutex> lock(_mutex_last_seq_map);
             LOG_F(3, "_last_seq_map size: %lu", _last_seq_map.size());
@@ -72,8 +73,9 @@ void ReliableMainServer::_tr_update_last_seq_map() {
                 }
             }
         }
-        sleep(1);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
     }
+    LOG_F(INFO, "RMS updateLastSeq process_stop=true; exiting");
 }
 
 void ReliableMainServer::start() {
@@ -84,4 +86,6 @@ void ReliableMainServer::start() {
 void ReliableMainServer::join() {
     _thread_update_last_seq_map.join();
     MainServer::join();
+    LOG_F(WARNING, "ReliableMainServer: joined all threads");
+
 }

--- a/ReliableMainServer.hpp
+++ b/ReliableMainServer.hpp
@@ -1,5 +1,6 @@
 #include <map>
 #include <mutex>
+#include "common.hpp"
 #include "MainServer.hpp"
 #include "packets.hpp"
 

--- a/Tracker.cpp
+++ b/Tracker.cpp
@@ -72,7 +72,7 @@ void Tracker::_update_status_node_map(){
 }
 
 
-void Tracker::_check_node_map(){
+void Tracker::_tr_check_node_map(){
     bool call_set_peer_lost=false;
     uint32_t actualTimestamp;
 
@@ -80,7 +80,7 @@ void Tracker::_check_node_map(){
 
     std::map<uint8_t, std::pair<Position, uint32_t>>::const_iterator it;
 
-    while (true) {
+    while (! process_stop) {
         
         _update_status_node_map();
 
@@ -103,13 +103,18 @@ void Tracker::_check_node_map(){
                 call_set_peer_lost = false;  // reset du booleen d'appel
             }
         }
-
-        sleep(_period_mapcheck);
+        std::this_thread::sleep_for(std::chrono::seconds(_period_mapcheck));
     }
+    LOG_F(INFO, "Tracker checkNodeMap - process_stop=true; exiting");
 }
 
 
 void Tracker::start() {
     loguru::set_thread_name("Tracker");
-    _check_node_map();
+    _tr_check_node_map();
+}
+
+void Tracker::join() {
+    _thread_check_node_map.join();
+    LOG_F(WARNING, "Tracker: joined all threads");
 }

--- a/Tracker.hpp
+++ b/Tracker.hpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <unistd.h>
 #include "loguru.hpp"
+#include "common.hpp"
 #include "packets.hpp"
 #include "Position.hpp"
 
@@ -24,7 +25,7 @@ private :
     void _reset_peer_lost_flag();
 
     void _update_status_node_map();
-    void _check_node_map();
+    void _tr_check_node_map();
 
 public :
     Tracker(unsigned short, unsigned short);
@@ -37,6 +38,7 @@ public :
     void start();
     void notify(Packet);
     bool is_peer_lost();
+    void join();
     
 };
 

--- a/common.hpp
+++ b/common.hpp
@@ -1,0 +1,9 @@
+#ifndef _COMMON_HPP_
+#define _COMMON_HPP_
+
+#include <atomic>
+
+/* Global to all threads of the process, initially set to false in main */
+extern std::atomic<bool> process_stop;
+
+#endif


### PR DESCRIPTION
- std::this_thread::sleep_for() instead of sleep()
- Fixed gracefuly exit